### PR TITLE
Freebsd support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,6 +18,9 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - all
+  - name: FreeBSD
+    versions:
+    - 10.2
   categories:
     - development
     - system

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,3 +13,6 @@
 
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
+
+- include: setup-FreeBSD.yml
+  when: ansible_os_family == 'FreeBSD'

--- a/tasks/setup-FreeBSD.yml
+++ b/tasks/setup-FreeBSD.yml
@@ -1,0 +1,10 @@
+---
+- name: Ensure Java is installed.
+  pkgng: "name={{ item }} state=present"
+  with_items: java_packages
+
+- name: ensure proc is mounted
+  mount: name=/proc fstype=procfs src=proc opts=rw state=mounted
+
+- name: ensure fdesc is mounted
+  mount: name=/dev/fd fstype=fdescfs src=fdesc opts=rw state=mounted

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,7 +1,7 @@
 ---
-# JDK version options include:
-#   - java
-#   - java-1.6.0-openjdk
-#   - java-1.7.0-openjdk
+# JDK version options for FreeBSD include:
+#   - openjdk
+#   - openjdk6
+#   - openjdk8
 __java_packages:
   - openjdk

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,0 +1,7 @@
+---
+# JDK version options include:
+#   - java
+#   - java-1.6.0-openjdk
+#   - java-1.7.0-openjdk
+__java_packages:
+  - openjdk


### PR DESCRIPTION
Hi Jeff,

This is hopefully the first of many such contributions. As I said, these integrations can be done reasonably clean. Basically include more var files and a switch for the tasks.
I have the first version of the PHP role as well, but since it's more complex it requires more testing.

Only question: FreeBSD OpenJDK requires additional mount points to be added (this is shown after a manual install of OpenJDK)
I felt it best to include the mount points so that the role is complete, but some people might want to do this manually or would like a switch.

Let me know if you want me to add a switch for this behaviour.
I'm respecting your role's default by using Java7. Overriding it works just like on the other platforms.

Thanks :)