### PR TITLE
Fix deprecation warning

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,4 +4,4 @@
 
 - name: Ensure Java is installed.
   apt: "name={{ item }} state=installed"
-  with_items: java_packages
+  with_items: "{{ java_packages }}"

--- a/tasks/setup-FreeBSD.yml
+++ b/tasks/setup-FreeBSD.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensure Java is installed.
   pkgng: "name={{ item }} state=present"
-  with_items: java_packages
+  with_items: "{{ java_packages }}"
 
 - name: ensure proc is mounted
   mount: name=/proc fstype=procfs src=proc opts=rw state=mounted

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,4 +1,4 @@
 ---
 - name: Ensure Java is installed.
   yum: "name={{ item }} state=installed"
-  with_items: java_packages
+  with_items: "{{ java_packages }}"


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your
playbooks so that the environment value uses the full variable syntax
({{java_packages}}). This feature will be removed in a future release.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```