### PR TITLE
Allow for escalating privaleges

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,11 +8,15 @@
   when: java_packages is not defined
 
 # Setup/install tasks.
-- include: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+- block:
+  - include: setup-RedHat.yml
+    when: ansible_os_family == 'RedHat'
 
-- include: setup-Debian.yml
-  when: ansible_os_family == 'Debian'
+  - include: setup-Debian.yml
+    when: ansible_os_family == 'Debian'
 
-- include: setup-FreeBSD.yml
-  when: ansible_os_family == 'FreeBSD'
+  - include: setup-FreeBSD.yml
+    when: ansible_os_family == 'FreeBSD'
+  become: yes
+  become_method: sudo
+  become_user: root


### PR DESCRIPTION
Fix for #13 

Added a become block around the include (because all included tasks require escalated privileges). 

**Notes:**

* `block` means that we need at least Ansible 2.0
* `become` means that we need at least Ansible 1.9

Let me know if you would prefer me to use do the privilege escalation inline (not use block), or if you would prefer that i use `sudo` instead of `become`