### PR TITLE
Allow to pass install_recommends to apt

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,5 +3,5 @@
   apt: update_cache=yes cache_valid_time=600
 
 - name: Ensure Java is installed.
-  apt: "name={{ item }} state=present"
+  apt: "name={{ item }} state=present install_recommends={{ apt_install_recommends|default(omit) }}"
   with_items: "{{ java_packages }}"


### PR DESCRIPTION
Hi,

java package can install lots of dependencies because it recommends `libxt` which comes with a lot of X11 friends :)

So I suggest to let user determine whether they want recommended packages via `apt_install_recommends` var.

What is your opinion about this ?
