### PR TITLE
fix when check for java_home

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,4 +35,4 @@
     src: java_home.sh.j2
     dest: /etc/profile.d/java_home.sh
     mode: 0644
-  when: java_home
+  when: java_home is defined


### PR DESCRIPTION
This code snippet produces an error in `tasks/main.yml`
`when: java_home`
The correct version is:
`when: java_home is defined`