### PR TITLE
support configurable custom apt ppa repositories (by default supporting openjdk-8 on Ubuntu <16.04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Set the version/development kit of Java to install, along with any other necessa
 
 If set, the role will set the global environment variable `JAVA_HOME` to this value.
 
+    # Ubuntu/Debian specific:
+    java_openjdk_ppa_repos_support: false
+
+If set, the role will enable usage of custom ppa repositories to support newer JDKs in older distros.
+The role only adds a repository for configured combinations (in var. `java_openjdk_ppa_mappings`).
+By default `java_openjdk_ppa_mappings` contains a mapping to support OpenJDK 8 on Ubuntu-14.04
+
 ## Dependencies
 
 None.
@@ -43,19 +50,16 @@ For RHEL / CentOS:
           java_packages:
             - java-1.8.0-openjdk
 
-For Ubuntu < 16.04:
+For Ubuntu:
 
-    - hosts: server
-      tasks:
-        - name: installing repo for Java 8 in Ubuntu
-  	      apt_repository: repo='ppa:openjdk-r/ppa'
-    
     - hosts: server
       roles:
         - role: geerlingguy.java
           when: "ansible_os_family == 'Debian'"
           java_packages:
             - openjdk-8-jdk
+          #ppa repos only required for Ubuntu < 16.04
+          java_openjdk_ppa_repos_support: true
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@
 # java_packages: []
 
 java_home: ""
+java_openjdk_ppa_repos_support: false

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,8 +1,13 @@
 ---
-- name: Add APT Repo for OpenJDK 8
-  apt_repository: repo='ppa:openjdk-r/ppa'
-  with_items: "{{ java_packages }}"
-  when: item == 'openjdk-8-jdk'
+- name: Add extra repository (only if we find a repository mapping supporting a pkg in 'java_packages')
+  apt_repository: repo={{item.repository_url}} state=present
+  when:
+   - java_openjdk_ppa_repos_support
+   - "{{ item.package in java_packages }}"
+   - "{{ ansible_distribution_version|version_compare(item.distro_version, item.version_comparator) }}"
+  with_items:
+    - "{{ java_openjdk_ppa_mappings | default([]) }}"
+
 
 - name: Update apt cache.
   apt: update_cache=yes cache_valid_time=600

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,6 +5,7 @@
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
+      changed_when: false
 
   roles:
     - role_under_test

--- a/vars/Ubuntu-14.04.yml
+++ b/vars/Ubuntu-14.04.yml
@@ -5,3 +5,9 @@
 #   - openjdk-7-jdk
 __java_packages:
   - openjdk-7-jdk
+
+__java_openjdk_ppa_mappings:
+  - package: openjdk-8-jdk
+    repository_url: 'ppa:openjdk-r/ppa'
+    distro_version: '16.04'
+    version_comparator: '<'


### PR DESCRIPTION
Add role support to install OpenJDK-8 on older Ubuntu versions (<v16.04) for ex, without requiring the user to take care about managing and writing any (duplicated) `apt_repository` (pre)tasks himself.

The implementation might seem a bit complex, but it is still short, flexible and offers:
* the change is fully downward-compatible (as the new feature is disabled by default)
* the provided 'mapping strategy' is flexible and future proof  
  * for ex. once the final openjdk-9 comes out, possibly it might require a custom ppa also for then older Ubuntu versions

ps: Feel free todo a stash-merge (as the PR also contains the original simple solution commit, which did not take care about later Ubuntu versions, that do not need an extra ppa anymore)