### PR TITLE
Remove apt cache update

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,7 +1,4 @@
 ---
-- name: Update apt cache.
-  apt: update_cache=yes cache_valid_time=600
-
 - name: Ensure Java is installed.
   apt: "name={{ item }} state=present"
   with_items: "{{ java_packages }}"


### PR DESCRIPTION
Is this cache update really necessary?
No repository has been added or removed.
It makes the role always give status changed.