### PR TITLE
Make java_home non-empty string conditional explicit instead of bare variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,4 +35,4 @@
     src: java_home.sh.j2
     dest: /etc/profile.d/java_home.sh
     mode: 0644
-  when: java_home
+  when: java_home is defined and java_home != ''


### PR DESCRIPTION
As discussed in issue #32 . Upstream stated that they don't support javascript-style truthy behavior for bare variables in conditionals. This PR changes the java_home conditional to use `is defined and != ''`