### PR TITLE
Add vars file for Ubuntu 16.10

### DIFF
--- a/vars/Ubuntu-16.10.yml
+++ b/vars/Ubuntu-16.10.yml
@@ -1,0 +1,7 @@
+---
+# JDK version options include:
+#   - java
+#   - openjdk-8-jdk
+#   - openjdk-9-jdk
+__java_packages:
+  - openjdk-8-jdk


### PR DESCRIPTION
This adds support for Ubuntu 16.10 (yakkety).

Without it, a playbook run fails with

```
TASK [geerlingguy.java : Include version-specific variables for Ubuntu.] *******
fatal: [jenkins]: FAILED! => {"ansible_facts": {}, "changed": false, "failed": true, 
"message": "Unable to find 'Ubuntu-16.10.yml' in expected paths."}
```

:octocat: 