### PR TITLE
Skip OS-specific vars when "java_packages" is set

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
-  when: ansible_distribution != 'Ubuntu' or ansible_distribution != 'Fedora'
+  when: (ansible_distribution != 'Ubuntu' or ansible_distribution != 'Fedora') and java_packages is not defined
 
 - name: Include OS-specific variables for Fedora.
   include_vars: "{{ ansible_distribution }}.yml"
-  when: ansible_distribution == 'Fedora'
+  when: ansible_distribution == 'Fedora' and java_packages is not defined
 
 - name: Include version-specific variables for Ubuntu.
   include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_distribution == 'Ubuntu' and java_packages is not defined
 
 - name: Define java_packages.
   set_fact:


### PR DESCRIPTION
It's me again 😇 

This is a follow up to #39 - I do realize that "OS specific variables" implies that there could be more than just the `__java_packages` var, but as there only this one variable is specified, would it be possible to go with it for now and refactor it when (if) the time comes?

This change would allow users with unmaintained Ubuntu versions to specify the `java_packages` variable to circumvent the problem described in #39.

:octocat: