### PR TITLE
Run apt-get update before installing the package.

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,4 @@
 ---
 - name: Ensure Java is installed.
-  apt: "name={{ item }} state=present"
+  apt: "name={{ item }} state=present update_cache=yes"
   with_items: "{{ java_packages }}"


### PR DESCRIPTION
Fixes missing apt package and message:

```
No package matching 'openjdk-8-jdk' is available
```

Fixes: #24