### PR TITLE
Installation and cleaning of Oracle Java 7, 8 and 9 for Debian

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,18 @@
 # Set java_packages if you would like to use a different version than the
 # default (OpenJDK 1.7).
 # java_packages: []
+#
+# And if you would like to use Oracle Java, then set this array:
+# java_packages:
+#   - oracle-java9-installer
+#   - oracle-java8-installer
+#   - oracle-java7-installer
+#   - ca-certificates
+#   - oracle-java8-set-default
+#
+# This example install Oracle Java 7, 8 and 9 and set as default 8.
 
 java_home: ""
+
+# Set java_cleanup to true if wyou would like clean (delete repos, keys and uninstall)
+java_cleanup: false

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,45 @@
 ---
+- name: Ensure the WebUpd8 repo key is present.
+  apt_key: id=EEA14886 keyserver=keyserver.ubuntu.com state=present
+  register: webupd8key
+  until: webupd8key|success
+  retries: 5
+  delay: 10
+  when: not java_cleanup and java_packages|join|search("oracle")
+
+- name: Removing WebUpd8 repo key.
+  apt_key: id=EEA14886 keyserver=keyserver.ubuntu.com state=absent
+  when: java_cleanup and java_packages|join|search("oracle")
+
+- name: Installing WebUpd8 repo Java PPA.
+  apt_repository: repo='{{ item }} http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main' state=present mode=0644
+  with_items:
+    - deb
+    - deb-src
+  when: not java_cleanup and java_packages|join|search("oracle")
+
+- name: Remove WebUpd8 repo Java PPA.
+  apt_repository: repo='{{ item }} http://ppa.launchpad.net/webupd8team/java/ubuntu xenial main' state=absent
+  with_items:
+    - deb
+    - deb-src
+  when: java_cleanup and java_packages|join|search("oracle")
+
+- name: Set Oracle Java License as accepted.
+  debconf: name='{{ item }}' question='shared/accepted-oracle-license-v1-1' value='true' vtype='select'
+  with_items:
+    - oracle-java6-installer
+    - oracle-java7-installer
+    - oracle-java8-installer
+    - oracle-java9-installer
+  when: not java_cleanup and java_packages|join|search("oracle")
+
 - name: Ensure Java is installed.
   apt: "name={{ item }} state=present"
   with_items: "{{ java_packages }}"
+  when: not java_cleanup
+
+- name: Remove Java.
+  apt: "name={{ item }} state=absent autoremove=true"
+  with_items: "{{ java_packages }}"
+  when: java_cleanup

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,5 +3,13 @@
 #   - java
 #   - openjdk-6-jdk
 #   - openjdk-7-jdk
+# and for Oracle Java:
+#   - oracle-java9-installer
+#   - oracle-java8-installer
+#   - oracle-java7-installer
+#   - ca-certificates
+#   - oracle-java9-set-default
+#   - oracle-java8-set-default
+#   - oracle-java7-set-default
 __java_packages:
   - openjdk-7-jdk


### PR DESCRIPTION
Installation and cleaning of Oracle Java 7, 8 and 9 for Debian from WebUpd8 Repo.