### PR TITLE
Allow installing openjdk-8 under Jessie

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,16 @@
 ---
+- set_fact:
+    backport_string: "{{ ansible_distribution_release }}-backports"
+  when: "ansible_distribution_release == 'jessie' and 'openjdk-8-jdk' in java_packages"
+
+- name: Install backports repo depending on packages
+  apt_repository:
+    repo: "deb http://ftp.debian.org/debian {{ backport_string }} main"
+  when: "{{ backport_string|default('') != '' }}"
+
 - name: Ensure Java is installed.
-  apt: "name={{ item }} state=present"
+  apt:
+    name: "{{ item }}"
+    state: present
+    default_release: "{{ backport_string|default(omit) }}"
   with_items: "{{ java_packages }}"


### PR DESCRIPTION
Tried to make this logic extensible and not to over-ride default behavior. 

Could use some tweaking to conditional logic for `backport_string`. Maybe move that
into a default variable that can be over-ridden instead ? Or make it even dumber logic and just force playbook runner to set an `install_deb_backports` toggle to true? 