### PR TITLE
Update apt cache on Debian systems

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,7 @@
 ---
+- name: Update apt cache.
+  apt: update_cache=yes cache_valid_time=3600
+
 - name: Ensure Java is installed.
   apt: "name={{ item }} state=present"
   with_items: "{{ java_packages }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,11 +1,5 @@
 ---
 - hosts: all
 
-  pre_tasks:
-    - name: Update apt cache.
-      apt: update_cache=yes cache_valid_time=600
-      when: ansible_os_family == 'Debian'
-      changed_when: false
-
   roles:
     - role_under_test


### PR DESCRIPTION
Hi Jeff,

I was trying to leverage this role to install Java on Vagrant with your `geerlingguy/ubuntu1604` box, however this role fails to install due to the mirrors for OpenJDK return a 404 (without a refresh of the apt cache). I noticed that your apache role for instance updates the apt cache prior to the installation of Apache2 (https://github.com/geerlingguy/ansible-role-apache/blob/master/tasks/setup-Debian.yml#L2), but this role lacks that similar step.

I saw that the tests for this role have a pre task of updating the aptitude cache prior to running but I believe for consistency across your roles for Debian this step is crucial.

I'm not sure if the output from ansible adds value but here it is nonetheless:

```bash
TASK [Gathering Facts] *********************************************************
ok: [default]

TASK [geerlingguy.java : Include OS-specific variables.] ***********************
ok: [default]

TASK [geerlingguy.java : Include OS-specific variables for Fedora.] ************
skipping: [default]

TASK [geerlingguy.java : Include version-specific variables for Ubuntu.] *******
ok: [default]

TASK [geerlingguy.java : Define java_packages.] ********************************
ok: [default]

TASK [geerlingguy.java : include] **********************************************
skipping: [default]

TASK [geerlingguy.java : include] **********************************************
included: /Users/nathan/Sites/ci.dentzau.com/playbooks/roles/geerlingguy.java/tasks/setup-Debian.yml for default

TASK [geerlingguy.java : Ensure Java is installed.] ****************************
failed: [default] (item=[u'openjdk-8-jdk']) => {"cache_update_time": 1493764674, "cache_updated": false, "failed": true, "item": ["openjdk-8-jdk"], "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'openjdk-8-jdk'' failed: E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/n/nss/libnss3-nssdb_3.28.4-0ubuntu0.16.04.1_all.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/n/nss/libnss3_3.28.4-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jre-headless_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-intel1_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-nouveau2_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-radeon1_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/t/tiff/libtiff5_4.0.6-1ubuntu0.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libgl1-mesa-dri_12.0.6-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libglapi-mesa_12.0.6-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libgl1-mesa-glx_12.0.6-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/p/pulseaudio/libpulse0_8.0-0ubuntu3.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jre_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jdk-headless_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jdk_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "rc": 100, "stderr": "E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/n/nss/libnss3-nssdb_3.28.4-0ubuntu0.16.04.1_all.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/n/nss/libnss3_3.28.4-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jre-headless_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-intel1_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-nouveau2_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-radeon1_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/t/tiff/libtiff5_4.0.6-1ubuntu0.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libgl1-mesa-dri_12.0.6-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libglapi-mesa_12.0.6-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libgl1-mesa-glx_12.0.6-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/p/pulseaudio/libpulse0_8.0-0ubuntu3.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jre_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jdk-headless_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jdk_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]\n\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "stderr_lines": ["E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/n/nss/libnss3-nssdb_3.28.4-0ubuntu0.16.04.1_all.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/n/nss/libnss3_3.28.4-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jre-headless_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-intel1_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-nouveau2_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/libd/libdrm/libdrm-radeon1_2.4.70-1~ubuntu16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/t/tiff/libtiff5_4.0.6-1ubuntu0.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libgl1-mesa-dri_12.0.6-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libglapi-mesa_12.0.6-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libgl1-mesa-glx_12.0.6-0ubuntu0.16.04.1_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/p/pulseaudio/libpulse0_8.0-0ubuntu3.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jre_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jdk-headless_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/o/openjdk-8/openjdk-8-jdk_8u121-b13-0ubuntu1.16.04.2_amd64.deb  404  Not Found [IP: 91.189.91.23 80]", "", "E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following packages were automatically installed and are no longer required:\n  libyaml-0-2 python-crypto python-ecdsa python-httplib2 python-jinja2\n  python-markupsafe python-paramiko python-pkg-resources python-setuptools\n  python-six python-yaml sshpass\nUse 'sudo apt autoremove' to remove them.\nThe following additional packages will be installed:\n  ca-certificates-java dbus-x11 fontconfig fontconfig-config fonts-dejavu-core\n  fonts-dejavu-extra gconf-service gconf-service-backend gconf2 gconf2-common\n  hicolor-icon-theme java-common libasound2 libasound2-data libasyncns0\n  libatk1.0-0 libatk1.0-data libavahi-client3 libavahi-common-data\n  libavahi-common3 libavahi-glib1 libbonobo2-0 libbonobo2-common libcairo2\n  libcanberra0 libcups2 libdatrie1 libdrm-amdgpu1 libdrm-intel1\n  libdrm-nouveau2 libdrm-radeon1 libflac8 libfontconfig1 libgconf-2-4\n  libgdk-pixbuf2.0-0 libgdk-pixbuf2.0-common libgif7 libgl1-mesa-dri\n  libgl1-mesa-glx libglapi-mesa libgnome-2-0 libgnome2-common libgnomevfs2-0\n  libgnomevfs2-common libgraphite2-3 libgtk2.0-0 libgtk2.0-bin\n  libgtk2.0-common libharfbuzz0b libice-dev libice6 libjbig0 libjpeg-turbo8\n  libjpeg8 liblcms2-2 libllvm3.8 libltdl7 libnspr4 libnss3 libnss3-nssdb\n  libogg0 liborbit-2-0 libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0\n  libpciaccess0 libpcsclite1 libpixman-1-0 libpthread-stubs0-dev libpulse0\n  libsm-dev libsm6 libsndfile1 libtdb1 libthai-data libthai0 libtiff5\n  libtxc-dxtn-s2tc0 libvorbis0a libvorbisenc2 libvorbisfile3 libx11-6\n  libx11-data libx11-dev libx11-doc libx11-xcb1 libxau-dev libxau6\n  libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0 libxcb-render0\n  libxcb-shm0 libxcb-sync1 libxcb1 libxcb1-dev libxcomposite1 libxcursor1\n  libxdamage1 libxdmcp-dev libxdmcp6 libxext6 libxfixes3 libxi6 libxinerama1\n  libxrandr2 libxrender1 libxshmfence1 libxt-dev libxt6 libxtst6 libxxf86vm1\n  openjdk-8-jdk-headless openjdk-8-jre openjdk-8-jre-headless\n  sound-theme-freedesktop x11-common x11proto-core-dev x11proto-input-dev\n  x11proto-kb-dev xorg-sgml-doctools xtrans-dev\nSuggested packages:\n  gconf-defaults-service default-jre libasound2-plugins alsa-utils\n  libbonobo2-bin libcanberra-gtk0 libcanberra-pulse cups-common desktop-base\n  libgnomevfs2-bin libgnomevfs2-extra gamin | fam gnome-mime-data\n  librsvg2-common gvfs libice-doc liblcms2-utils pcscd pulseaudio libsm-doc\n  libxcb-doc libxt-doc openjdk-8-demo openjdk-8-source visualvm\n  icedtea-8-plugin openjdk-8-jre-jamvm libnss-mdns fonts-ipafont-gothic\n  fonts-ipafont-mincho ttf-wqy-microhei | ttf-wqy-zenhei fonts-indic\nThe following NEW packages will be installed:\n  ca-certificates-java dbus-x11 fontconfig fontconfig-config fonts-dejavu-core\n  fonts-dejavu-extra gconf-service gconf-service-backend gconf2 gconf2-common\n  hicolor-icon-theme java-common libasound2 libasound2-data libasyncns0\n  libatk1.0-0 libatk1.0-data libavahi-client3 libavahi-common-data\n  libavahi-common3 libavahi-glib1 libbonobo2-0 libbonobo2-common libcairo2\n  libcanberra0 libcups2 libdatrie1 libdrm-amdgpu1 libdrm-intel1\n  libdrm-nouveau2 libdrm-radeon1 libflac8 libfontconfig1 libgconf-2-4\n  libgdk-pixbuf2.0-0 libgdk-pixbuf2.0-common libgif7 libgl1-mesa-dri\n  libgl1-mesa-glx libglapi-mesa libgnome-2-0 libgnome2-common libgnomevfs2-0\n  libgnomevfs2-common libgraphite2-3 libgtk2.0-0 libgtk2.0-bin\n  libgtk2.0-common libharfbuzz0b libice-dev libice6 libjbig0 libjpeg-turbo8\n  libjpeg8 liblcms2-2 libllvm3.8 libltdl7 libnspr4 libnss3 libnss3-nssdb\n  libogg0 liborbit-2-0 libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0\n  libpciaccess0 libpcsclite1 libpixman-1-0 libpthread-stubs0-dev libpulse0\n  libsm-dev libsm6 libsndfile1 libtdb1 libthai-data libthai0 libtiff5\n  libtxc-dxtn-s2tc0 libvorbis0a libvorbisenc2 libvorbisfile3 libx11-6\n  libx11-data libx11-dev libx11-doc libx11-xcb1 libxau-dev libxau6\n  libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0 libxcb-render0\n  libxcb-shm0 libxcb-sync1 libxcb1 libxcb1-dev libxcomposite1 libxcursor1\n  libxdamage1 libxdmcp-dev libxdmcp6 libxext6 libxfixes3 libxi6 libxinerama1\n  libxrandr2 libxrender1 libxshmfence1 libxt-dev libxt6 libxtst6 libxxf86vm1\n  openjdk-8-jdk openjdk-8-jdk-headless openjdk-8-jre openjdk-8-jre-headless\n  sound-theme-freedesktop x11-common x11proto-core-dev x11proto-input-dev\n  x11proto-kb-dev xorg-sgml-doctools xtrans-dev\n0 upgraded, 124 newly installed, 0 to remove and 3 not upgraded.\nNeed to get 66.5 MB of archives.\nAfter this operation, 364 MB of additional disk space will be used.\nGet:1 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxau6 amd64 1:1.0.8-1 [8376 B]\nGet:2 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxdmcp6 amd64 1:1.1.2-1.1 [11.0 kB]\nGet:3 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb1 amd64 1.11.1-1ubuntu1 [40.0 kB]\nGet:4 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libx11-data all 2:1.6.3-1ubuntu2 [113 kB]\nGet:5 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libx11-6 amd64 2:1.6.3-1ubuntu2 [571 kB]\nGet:6 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxext6 amd64 2:1.3.3-1 [29.4 kB]\nGet:7 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 fonts-dejavu-core all 2.35-1 [1039 kB]\nGet:8 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 fontconfig-config all 2.11.94-0ubuntu1.1 [49.9 kB]\nGet:9 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libfontconfig1 amd64 2.11.94-0ubuntu1.1 [131 kB]\nGet:10 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 fontconfig amd64 2.11.94-0ubuntu1.1 [178 kB]\nGet:11 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libasyncns0 amd64 0.8-5build1 [12.3 kB]\nGet:12 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libbonobo2-common all 2.32.1-3 [34.7 kB]\nGet:13 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 liborbit-2-0 amd64 1:2.14.19-1build1 [140 kB]\nGet:14 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libbonobo2-0 amd64 2.32.1-3 [211 kB]\nGet:15 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 x11-common all 1:7.7+13ubuntu3 [22.4 kB]\nGet:16 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libice6 amd64 2:1.0.9-1 [39.2 kB]\nGet:17 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libjpeg-turbo8 amd64 1.4.2-0ubuntu3 [111 kB]\nGet:18 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 liblcms2-2 amd64 2.6-3ubuntu2 [137 kB]\nGet:19 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libogg0 amd64 1.3.2-1 [17.2 kB]\nGet:20 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libsm6 amd64 2:1.2.2-1 [15.8 kB]\nGet:21 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcomposite1 amd64 1:0.4.4-1 [7714 B]\nGet:22 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxfixes3 amd64 1:5.0.1-2 [11.1 kB]\nGet:23 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxrender1 amd64 1:0.9.9-0ubuntu1 [18.5 kB]\nGet:24 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcursor1 amd64 1:1.1.14-1 [22.8 kB]\nGet:25 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxdamage1 amd64 1:1.1.4-2 [6946 B]\nGet:26 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxinerama1 amd64 2:1.1.3-1 [7908 B]\nGet:27 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxshmfence1 amd64 1.2-1 [5042 B]\nGet:28 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxtst6 amd64 2:1.2.2-1 [14.1 kB]\nGet:29 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxxf86vm1 amd64 1:1.1.4-1 [10.6 kB]\nGet:30 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnspr4 amd64 2:4.13.1-0ubuntu0.16.04.1 [112 kB]\nIgn:31 http://us.archive.ubuntu.com/ubuntu xenial-updates/main i386 libnss3-nssdb all 2:3.28.4-0ubuntu0.16.04.1\nErr:32 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libnss3 amd64 2:3.28.4-0ubuntu0.16.04.1\n  404  Not Found [IP: 91.189.91.23 80]\nGet:33 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 ca-certificates-java all 20160321 [12.9 kB]\nGet:34 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 java-common all 0.56ubuntu2 [7742 B]\nGet:35 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libavahi-common-data amd64 0.6.32~rc+dfsg-1ubuntu2 [21.7 kB]\nGet:36 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libavahi-common3 amd64 0.6.32~rc+dfsg-1ubuntu2 [21.6 kB]\nGet:37 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libavahi-client3 amd64 0.6.32~rc+dfsg-1ubuntu2 [25.1 kB]\nGet:38 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libcups2 amd64 2.1.3-4 [197 kB]\nGet:39 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libjpeg8 amd64 8c-2ubuntu8 [2194 B]\nGet:40 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libpcsclite1 amd64 1.8.14-1ubuntu1.16.04.1 [21.4 kB]\nGet:41 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxi6 amd64 2:1.7.6-1 [28.6 kB]\nIgn:42 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jre-headless amd64 8u121-b13-0ubuntu1.16.04.2\nGet:43 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libjbig0 amd64 2.1-3.1 [26.6 kB]\nGet:44 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libtxc-dxtn-s2tc0 amd64 0~git20131104-1.1 [51.8 kB]\nGet:45 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 dbus-x11 amd64 1.10.6-1ubuntu3.3 [21.4 kB]\nGet:46 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 fonts-dejavu-extra all 2.35-1 [1749 kB]\nErr:32 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libnss3 amd64 2:3.28.4-0ubuntu0.16.04.1\n  404  Not Found [IP: 91.189.91.23 80]\nGet:47 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 gconf2-common all 3.2.6-3ubuntu6 [21.0 kB]\nGet:48 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgconf-2-4 amd64 3.2.6-3ubuntu6 [84.6 kB]\nGet:49 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 gconf-service-backend amd64 3.2.6-3ubuntu6 [57.5 kB]\nGet:50 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 gconf-service amd64 3.2.6-3ubuntu6 [2046 B]\nGet:51 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 gconf2 amd64 3.2.6-3ubuntu6 [65.8 kB]\nGet:52 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 hicolor-icon-theme all 0.15-0ubuntu1 [7750 B]\nGet:53 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libasound2-data all 1.1.0-0ubuntu1 [29.4 kB]\nErr:42 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jre-headless amd64 8u121-b13-0ubuntu1.16.04.2\n  404  Not Found [IP: 91.189.91.23 80]\nGet:54 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libasound2 amd64 1.1.0-0ubuntu1 [350 kB]\nGet:55 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libatk1.0-data all 2.18.0-1 [17.1 kB]\nGet:56 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libatk1.0-0 amd64 2.18.0-1 [56.9 kB]\nGet:57 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libavahi-glib1 amd64 0.6.32~rc+dfsg-1ubuntu2 [7726 B]\nGet:58 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpixman-1-0 amd64 0.33.6-1 [231 kB]\nGet:59 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-render0 amd64 1.11.1-1ubuntu1 [11.4 kB]\nGet:60 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-shm0 amd64 1.11.1-1ubuntu1 [5588 B]\nGet:61 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libcairo2 amd64 1.14.6-1 [555 kB]\nGet:62 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libltdl7 amd64 2.4.6-0.1 [38.3 kB]\nGet:63 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libtdb1 amd64 1.3.8-2 [38.2 kB]\nGet:64 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libvorbis0a amd64 1.3.5-3 [86.8 kB]\nGet:65 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libvorbisfile3 amd64 1.3.5-3 [15.9 kB]\nGet:66 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 sound-theme-freedesktop all 0.8-1 [385 kB]\nGet:67 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libcanberra0 amd64 0.30-2.1ubuntu1 [37.4 kB]\nGet:68 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libdatrie1 amd64 0.2.10-2 [17.3 kB]\nErr:69 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libdrm-amdgpu1 amd64 2.4.70-1~ubuntu16.04.1\n  404  Not Found [IP: 91.189.91.23 80]\nGet:70 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpciaccess0 amd64 0.13.4-1 [18.1 kB]\nErr:71 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libdrm-intel1 amd64 2.4.70-1~ubuntu16.04.1\n  404  Not Found [IP: 91.189.91.23 80]\nErr:72 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libdrm-nouveau2 amd64 2.4.70-1~ubuntu16.04.1\n  404  Not Found [IP: 91.189.91.23 80]\nErr:73 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libdrm-radeon1 amd64 2.4.70-1~ubuntu16.04.1\n  404  Not Found [IP: 91.189.91.23 80]\nGet:74 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libflac8 amd64 1.3.1-4 [210 kB]\nErr:75 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libtiff5 amd64 4.0.6-1ubuntu0.1\n  404  Not Found [IP: 91.189.91.23 80]\nGet:76 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgdk-pixbuf2.0-common all 2.32.2-1ubuntu1.2 [10.2 kB]\nGet:77 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgdk-pixbuf2.0-0 amd64 2.32.2-1ubuntu1.2 [158 kB]\nGet:78 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgif7 amd64 5.1.4-0.3~16.04 [30.5 kB]\nGet:79 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libllvm3.8 amd64 1:3.8-2ubuntu4 [10.3 MB]\nErr:75 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libtiff5 amd64 4.0.6-1ubuntu0.1\n  404  Not Found [IP: 91.189.91.23 80]\nErr:80 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgl1-mesa-dri amd64 12.0.6-0ubuntu0.16.04.1\n  404  Not Found [IP: 91.189.91.23 80]\nErr:81 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libglapi-mesa amd64 12.0.6-0ubuntu0.16.04.1\n  404  Not Found [IP: 91.189.91.23 80]\nGet:82 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libx11-xcb1 amd64 2:1.6.3-1ubuntu2 [8956 B]\nGet:83 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-dri2-0 amd64 1.11.1-1ubuntu1 [6882 B]\nGet:84 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-dri3-0 amd64 1.11.1-1ubuntu1 [5218 B]\nGet:85 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-glx0 amd64 1.11.1-1ubuntu1 [20.9 kB]\nGet:86 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-present0 amd64 1.11.1-1ubuntu1 [5218 B]\nGet:87 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-sync1 amd64 1.11.1-1ubuntu1 [8324 B]\nErr:88 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgl1-mesa-glx amd64 12.0.6-0ubuntu0.16.04.1\n  404  Not Found [IP: 91.189.91.23 80]\nGet:89 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgnomevfs2-common amd64 1:2.24.4-6.1ubuntu1 [23.0 kB]\nGet:90 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgnomevfs2-0 amd64 1:2.24.4-6.1ubuntu1 [213 kB]\nGet:91 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgnome2-common all 2.32.1-5ubuntu1 [33.5 kB]\nGet:92 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgnome-2-0 amd64 2.32.1-5ubuntu1 [53.7 kB]\nGet:93 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgraphite2-3 amd64 1.3.6-1ubuntu1 [70.8 kB]\nGet:94 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgtk2.0-common all 2.24.30-1ubuntu1 [123 kB]\nGet:95 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libthai-data all 0.1.24-2 [131 kB]\nGet:96 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libthai0 amd64 0.1.24-2 [17.3 kB]\nGet:97 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpango-1.0-0 amd64 1.38.1-1 [148 kB]\nGet:98 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libharfbuzz0b amd64 1.0.1-1ubuntu0.1 [140 kB]\nGet:99 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpangoft2-1.0-0 amd64 1.38.1-1 [33.3 kB]\nGet:100 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpangocairo-1.0-0 amd64 1.38.1-1 [20.5 kB]\nGet:101 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxrandr2 amd64 2:1.5.0-1 [17.6 kB]\nGet:102 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgtk2.0-0 amd64 2.24.30-1ubuntu1 [1777 kB]\nGet:103 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgtk2.0-bin amd64 2.24.30-1ubuntu1 [9820 B]\nGet:104 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 xorg-sgml-doctools all 1:1.11-1 [12.9 kB]\nGet:105 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 x11proto-core-dev all 7.0.28-2ubuntu1 [254 kB]\nGet:106 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libice-dev amd64 2:1.0.9-1 [44.9 kB]\nGet:107 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpthread-stubs0-dev amd64 0.3-4 [4068 B]\nGet:108 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libvorbisenc2 amd64 1.3.5-3 [70.7 kB]\nGet:109 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libsndfile1 amd64 1.0.25-10 [137 kB]\nErr:110 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libpulse0 amd64 1:8.0-0ubuntu3.2\n  404  Not Found [IP: 91.189.91.23 80]\nGet:111 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libsm-dev amd64 2:1.2.2-1 [16.2 kB]\nGet:112 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxau-dev amd64 1:1.0.8-1 [11.1 kB]\nGet:113 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxdmcp-dev amd64 1:1.1.2-1.1 [25.1 kB]\nGet:114 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 x11proto-input-dev all 2.3.1-1 [118 kB]\nGet:115 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 x11proto-kb-dev all 1.0.7-0ubuntu1 [224 kB]\nGet:116 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 xtrans-dev all 1.3.5-1 [70.5 kB]\nGet:117 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb1-dev amd64 1.11.1-1ubuntu1 [74.2 kB]\nGet:118 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libx11-dev amd64 2:1.6.3-1ubuntu2 [642 kB]\nGet:119 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libx11-doc all 2:1.6.3-1ubuntu2 [1465 kB]\nGet:120 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxt6 amd64 1:1.1.5-0ubuntu1 [160 kB]\nGet:121 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxt-dev amd64 1:1.1.5-0ubuntu1 [394 kB]\nErr:122 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jre amd64 8u121-b13-0ubuntu1.16.04.2\n  404  Not Found [IP: 91.189.91.23 80]\nIgn:123 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jdk-headless amd64 8u121-b13-0ubuntu1.16.04.2\nErr:122 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jre amd64 8u121-b13-0ubuntu1.16.04.2\n  404  Not Found [IP: 91.189.91.23 80]\nIgn:124 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jdk amd64 8u121-b13-0ubuntu1.16.04.2\nIgn:31 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libnss3-nssdb all 2:3.28.4-0ubuntu0.16.04.1\nErr:123 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jdk-headless amd64 8u121-b13-0ubuntu1.16.04.2\n  404  Not Found [IP: 91.189.91.23 80]\nErr:124 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jdk amd64 8u121-b13-0ubuntu1.16.04.2\n  404  Not Found [IP: 91.189.91.23 80]\nErr:31 http://security.ubuntu.com/ubuntu xenial-security/main i386 libnss3-nssdb all 2:3.28.4-0ubuntu0.16.04.1\n  404  Not Found [IP: 91.189.91.23 80]\nErr:31 http://security.ubuntu.com/ubuntu xenial-security/main i386 libnss3-nssdb all 2:3.28.4-0ubuntu0.16.04.1\n  404  Not Found [IP: 91.189.91.23 80]\nFetched 24.7 MB in 6s (3871 kB/s)\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following packages were automatically installed and are no longer required:", "  libyaml-0-2 python-crypto python-ecdsa python-httplib2 python-jinja2", "  python-markupsafe python-paramiko python-pkg-resources python-setuptools", "  python-six python-yaml sshpass", "Use 'sudo apt autoremove' to remove them.", "The following additional packages will be installed:", "  ca-certificates-java dbus-x11 fontconfig fontconfig-config fonts-dejavu-core", "  fonts-dejavu-extra gconf-service gconf-service-backend gconf2 gconf2-common", "  hicolor-icon-theme java-common libasound2 libasound2-data libasyncns0", "  libatk1.0-0 libatk1.0-data libavahi-client3 libavahi-common-data", "  libavahi-common3 libavahi-glib1 libbonobo2-0 libbonobo2-common libcairo2", "  libcanberra0 libcups2 libdatrie1 libdrm-amdgpu1 libdrm-intel1", "  libdrm-nouveau2 libdrm-radeon1 libflac8 libfontconfig1 libgconf-2-4", "  libgdk-pixbuf2.0-0 libgdk-pixbuf2.0-common libgif7 libgl1-mesa-dri", "  libgl1-mesa-glx libglapi-mesa libgnome-2-0 libgnome2-common libgnomevfs2-0", "  libgnomevfs2-common libgraphite2-3 libgtk2.0-0 libgtk2.0-bin", "  libgtk2.0-common libharfbuzz0b libice-dev libice6 libjbig0 libjpeg-turbo8", "  libjpeg8 liblcms2-2 libllvm3.8 libltdl7 libnspr4 libnss3 libnss3-nssdb", "  libogg0 liborbit-2-0 libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0", "  libpciaccess0 libpcsclite1 libpixman-1-0 libpthread-stubs0-dev libpulse0", "  libsm-dev libsm6 libsndfile1 libtdb1 libthai-data libthai0 libtiff5", "  libtxc-dxtn-s2tc0 libvorbis0a libvorbisenc2 libvorbisfile3 libx11-6", "  libx11-data libx11-dev libx11-doc libx11-xcb1 libxau-dev libxau6", "  libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0 libxcb-render0", "  libxcb-shm0 libxcb-sync1 libxcb1 libxcb1-dev libxcomposite1 libxcursor1", "  libxdamage1 libxdmcp-dev libxdmcp6 libxext6 libxfixes3 libxi6 libxinerama1", "  libxrandr2 libxrender1 libxshmfence1 libxt-dev libxt6 libxtst6 libxxf86vm1", "  openjdk-8-jdk-headless openjdk-8-jre openjdk-8-jre-headless", "  sound-theme-freedesktop x11-common x11proto-core-dev x11proto-input-dev", "  x11proto-kb-dev xorg-sgml-doctools xtrans-dev", "Suggested packages:", "  gconf-defaults-service default-jre libasound2-plugins alsa-utils", "  libbonobo2-bin libcanberra-gtk0 libcanberra-pulse cups-common desktop-base", "  libgnomevfs2-bin libgnomevfs2-extra gamin | fam gnome-mime-data", "  librsvg2-common gvfs libice-doc liblcms2-utils pcscd pulseaudio libsm-doc", "  libxcb-doc libxt-doc openjdk-8-demo openjdk-8-source visualvm", "  icedtea-8-plugin openjdk-8-jre-jamvm libnss-mdns fonts-ipafont-gothic", "  fonts-ipafont-mincho ttf-wqy-microhei | ttf-wqy-zenhei fonts-indic", "The following NEW packages will be installed:", "  ca-certificates-java dbus-x11 fontconfig fontconfig-config fonts-dejavu-core", "  fonts-dejavu-extra gconf-service gconf-service-backend gconf2 gconf2-common", "  hicolor-icon-theme java-common libasound2 libasound2-data libasyncns0", "  libatk1.0-0 libatk1.0-data libavahi-client3 libavahi-common-data", "  libavahi-common3 libavahi-glib1 libbonobo2-0 libbonobo2-common libcairo2", "  libcanberra0 libcups2 libdatrie1 libdrm-amdgpu1 libdrm-intel1", "  libdrm-nouveau2 libdrm-radeon1 libflac8 libfontconfig1 libgconf-2-4", "  libgdk-pixbuf2.0-0 libgdk-pixbuf2.0-common libgif7 libgl1-mesa-dri", "  libgl1-mesa-glx libglapi-mesa libgnome-2-0 libgnome2-common libgnomevfs2-0", "  libgnomevfs2-common libgraphite2-3 libgtk2.0-0 libgtk2.0-bin", "  libgtk2.0-common libharfbuzz0b libice-dev libice6 libjbig0 libjpeg-turbo8", "  libjpeg8 liblcms2-2 libllvm3.8 libltdl7 libnspr4 libnss3 libnss3-nssdb", "  libogg0 liborbit-2-0 libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0", "  libpciaccess0 libpcsclite1 libpixman-1-0 libpthread-stubs0-dev libpulse0", "  libsm-dev libsm6 libsndfile1 libtdb1 libthai-data libthai0 libtiff5", "  libtxc-dxtn-s2tc0 libvorbis0a libvorbisenc2 libvorbisfile3 libx11-6", "  libx11-data libx11-dev libx11-doc libx11-xcb1 libxau-dev libxau6", "  libxcb-dri2-0 libxcb-dri3-0 libxcb-glx0 libxcb-present0 libxcb-render0", "  libxcb-shm0 libxcb-sync1 libxcb1 libxcb1-dev libxcomposite1 libxcursor1", "  libxdamage1 libxdmcp-dev libxdmcp6 libxext6 libxfixes3 libxi6 libxinerama1", "  libxrandr2 libxrender1 libxshmfence1 libxt-dev libxt6 libxtst6 libxxf86vm1", "  openjdk-8-jdk openjdk-8-jdk-headless openjdk-8-jre openjdk-8-jre-headless", "  sound-theme-freedesktop x11-common x11proto-core-dev x11proto-input-dev", "  x11proto-kb-dev xorg-sgml-doctools xtrans-dev", "0 upgraded, 124 newly installed, 0 to remove and 3 not upgraded.", "Need to get 66.5 MB of archives.", "After this operation, 364 MB of additional disk space will be used.", "Get:1 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxau6 amd64 1:1.0.8-1 [8376 B]", "Get:2 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxdmcp6 amd64 1:1.1.2-1.1 [11.0 kB]", "Get:3 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb1 amd64 1.11.1-1ubuntu1 [40.0 kB]", "Get:4 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libx11-data all 2:1.6.3-1ubuntu2 [113 kB]", "Get:5 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libx11-6 amd64 2:1.6.3-1ubuntu2 [571 kB]", "Get:6 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxext6 amd64 2:1.3.3-1 [29.4 kB]", "Get:7 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 fonts-dejavu-core all 2.35-1 [1039 kB]", "Get:8 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 fontconfig-config all 2.11.94-0ubuntu1.1 [49.9 kB]", "Get:9 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libfontconfig1 amd64 2.11.94-0ubuntu1.1 [131 kB]", "Get:10 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 fontconfig amd64 2.11.94-0ubuntu1.1 [178 kB]", "Get:11 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libasyncns0 amd64 0.8-5build1 [12.3 kB]", "Get:12 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libbonobo2-common all 2.32.1-3 [34.7 kB]", "Get:13 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 liborbit-2-0 amd64 1:2.14.19-1build1 [140 kB]", "Get:14 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libbonobo2-0 amd64 2.32.1-3 [211 kB]", "Get:15 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 x11-common all 1:7.7+13ubuntu3 [22.4 kB]", "Get:16 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libice6 amd64 2:1.0.9-1 [39.2 kB]", "Get:17 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libjpeg-turbo8 amd64 1.4.2-0ubuntu3 [111 kB]", "Get:18 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 liblcms2-2 amd64 2.6-3ubuntu2 [137 kB]", "Get:19 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libogg0 amd64 1.3.2-1 [17.2 kB]", "Get:20 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libsm6 amd64 2:1.2.2-1 [15.8 kB]", "Get:21 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcomposite1 amd64 1:0.4.4-1 [7714 B]", "Get:22 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxfixes3 amd64 1:5.0.1-2 [11.1 kB]", "Get:23 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxrender1 amd64 1:0.9.9-0ubuntu1 [18.5 kB]", "Get:24 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcursor1 amd64 1:1.1.14-1 [22.8 kB]", "Get:25 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxdamage1 amd64 1:1.1.4-2 [6946 B]", "Get:26 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxinerama1 amd64 2:1.1.3-1 [7908 B]", "Get:27 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxshmfence1 amd64 1.2-1 [5042 B]", "Get:28 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxtst6 amd64 2:1.2.2-1 [14.1 kB]", "Get:29 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxxf86vm1 amd64 1:1.1.4-1 [10.6 kB]", "Get:30 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libnspr4 amd64 2:4.13.1-0ubuntu0.16.04.1 [112 kB]", "Ign:31 http://us.archive.ubuntu.com/ubuntu xenial-updates/main i386 libnss3-nssdb all 2:3.28.4-0ubuntu0.16.04.1", "Err:32 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libnss3 amd64 2:3.28.4-0ubuntu0.16.04.1", "  404  Not Found [IP: 91.189.91.23 80]", "Get:33 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 ca-certificates-java all 20160321 [12.9 kB]", "Get:34 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 java-common all 0.56ubuntu2 [7742 B]", "Get:35 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libavahi-common-data amd64 0.6.32~rc+dfsg-1ubuntu2 [21.7 kB]", "Get:36 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libavahi-common3 amd64 0.6.32~rc+dfsg-1ubuntu2 [21.6 kB]", "Get:37 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libavahi-client3 amd64 0.6.32~rc+dfsg-1ubuntu2 [25.1 kB]", "Get:38 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libcups2 amd64 2.1.3-4 [197 kB]", "Get:39 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libjpeg8 amd64 8c-2ubuntu8 [2194 B]", "Get:40 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libpcsclite1 amd64 1.8.14-1ubuntu1.16.04.1 [21.4 kB]", "Get:41 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxi6 amd64 2:1.7.6-1 [28.6 kB]", "Ign:42 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jre-headless amd64 8u121-b13-0ubuntu1.16.04.2", "Get:43 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libjbig0 amd64 2.1-3.1 [26.6 kB]", "Get:44 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libtxc-dxtn-s2tc0 amd64 0~git20131104-1.1 [51.8 kB]", "Get:45 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 dbus-x11 amd64 1.10.6-1ubuntu3.3 [21.4 kB]", "Get:46 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 fonts-dejavu-extra all 2.35-1 [1749 kB]", "Err:32 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libnss3 amd64 2:3.28.4-0ubuntu0.16.04.1", "  404  Not Found [IP: 91.189.91.23 80]", "Get:47 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 gconf2-common all 3.2.6-3ubuntu6 [21.0 kB]", "Get:48 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgconf-2-4 amd64 3.2.6-3ubuntu6 [84.6 kB]", "Get:49 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 gconf-service-backend amd64 3.2.6-3ubuntu6 [57.5 kB]", "Get:50 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 gconf-service amd64 3.2.6-3ubuntu6 [2046 B]", "Get:51 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 gconf2 amd64 3.2.6-3ubuntu6 [65.8 kB]", "Get:52 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 hicolor-icon-theme all 0.15-0ubuntu1 [7750 B]", "Get:53 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libasound2-data all 1.1.0-0ubuntu1 [29.4 kB]", "Err:42 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jre-headless amd64 8u121-b13-0ubuntu1.16.04.2", "  404  Not Found [IP: 91.189.91.23 80]", "Get:54 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libasound2 amd64 1.1.0-0ubuntu1 [350 kB]", "Get:55 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libatk1.0-data all 2.18.0-1 [17.1 kB]", "Get:56 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libatk1.0-0 amd64 2.18.0-1 [56.9 kB]", "Get:57 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libavahi-glib1 amd64 0.6.32~rc+dfsg-1ubuntu2 [7726 B]", "Get:58 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpixman-1-0 amd64 0.33.6-1 [231 kB]", "Get:59 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-render0 amd64 1.11.1-1ubuntu1 [11.4 kB]", "Get:60 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-shm0 amd64 1.11.1-1ubuntu1 [5588 B]", "Get:61 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libcairo2 amd64 1.14.6-1 [555 kB]", "Get:62 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libltdl7 amd64 2.4.6-0.1 [38.3 kB]", "Get:63 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libtdb1 amd64 1.3.8-2 [38.2 kB]", "Get:64 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libvorbis0a amd64 1.3.5-3 [86.8 kB]", "Get:65 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libvorbisfile3 amd64 1.3.5-3 [15.9 kB]", "Get:66 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 sound-theme-freedesktop all 0.8-1 [385 kB]", "Get:67 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libcanberra0 amd64 0.30-2.1ubuntu1 [37.4 kB]", "Get:68 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libdatrie1 amd64 0.2.10-2 [17.3 kB]", "Err:69 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libdrm-amdgpu1 amd64 2.4.70-1~ubuntu16.04.1", "  404  Not Found [IP: 91.189.91.23 80]", "Get:70 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpciaccess0 amd64 0.13.4-1 [18.1 kB]", "Err:71 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libdrm-intel1 amd64 2.4.70-1~ubuntu16.04.1", "  404  Not Found [IP: 91.189.91.23 80]", "Err:72 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libdrm-nouveau2 amd64 2.4.70-1~ubuntu16.04.1", "  404  Not Found [IP: 91.189.91.23 80]", "Err:73 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libdrm-radeon1 amd64 2.4.70-1~ubuntu16.04.1", "  404  Not Found [IP: 91.189.91.23 80]", "Get:74 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libflac8 amd64 1.3.1-4 [210 kB]", "Err:75 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libtiff5 amd64 4.0.6-1ubuntu0.1", "  404  Not Found [IP: 91.189.91.23 80]", "Get:76 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgdk-pixbuf2.0-common all 2.32.2-1ubuntu1.2 [10.2 kB]", "Get:77 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgdk-pixbuf2.0-0 amd64 2.32.2-1ubuntu1.2 [158 kB]", "Get:78 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgif7 amd64 5.1.4-0.3~16.04 [30.5 kB]", "Get:79 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libllvm3.8 amd64 1:3.8-2ubuntu4 [10.3 MB]", "Err:75 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libtiff5 amd64 4.0.6-1ubuntu0.1", "  404  Not Found [IP: 91.189.91.23 80]", "Err:80 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgl1-mesa-dri amd64 12.0.6-0ubuntu0.16.04.1", "  404  Not Found [IP: 91.189.91.23 80]", "Err:81 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libglapi-mesa amd64 12.0.6-0ubuntu0.16.04.1", "  404  Not Found [IP: 91.189.91.23 80]", "Get:82 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libx11-xcb1 amd64 2:1.6.3-1ubuntu2 [8956 B]", "Get:83 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-dri2-0 amd64 1.11.1-1ubuntu1 [6882 B]", "Get:84 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-dri3-0 amd64 1.11.1-1ubuntu1 [5218 B]", "Get:85 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-glx0 amd64 1.11.1-1ubuntu1 [20.9 kB]", "Get:86 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-present0 amd64 1.11.1-1ubuntu1 [5218 B]", "Get:87 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb-sync1 amd64 1.11.1-1ubuntu1 [8324 B]", "Err:88 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libgl1-mesa-glx amd64 12.0.6-0ubuntu0.16.04.1", "  404  Not Found [IP: 91.189.91.23 80]", "Get:89 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgnomevfs2-common amd64 1:2.24.4-6.1ubuntu1 [23.0 kB]", "Get:90 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgnomevfs2-0 amd64 1:2.24.4-6.1ubuntu1 [213 kB]", "Get:91 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgnome2-common all 2.32.1-5ubuntu1 [33.5 kB]", "Get:92 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgnome-2-0 amd64 2.32.1-5ubuntu1 [53.7 kB]", "Get:93 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgraphite2-3 amd64 1.3.6-1ubuntu1 [70.8 kB]", "Get:94 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgtk2.0-common all 2.24.30-1ubuntu1 [123 kB]", "Get:95 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libthai-data all 0.1.24-2 [131 kB]", "Get:96 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libthai0 amd64 0.1.24-2 [17.3 kB]", "Get:97 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpango-1.0-0 amd64 1.38.1-1 [148 kB]", "Get:98 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libharfbuzz0b amd64 1.0.1-1ubuntu0.1 [140 kB]", "Get:99 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpangoft2-1.0-0 amd64 1.38.1-1 [33.3 kB]", "Get:100 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpangocairo-1.0-0 amd64 1.38.1-1 [20.5 kB]", "Get:101 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxrandr2 amd64 2:1.5.0-1 [17.6 kB]", "Get:102 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgtk2.0-0 amd64 2.24.30-1ubuntu1 [1777 kB]", "Get:103 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libgtk2.0-bin amd64 2.24.30-1ubuntu1 [9820 B]", "Get:104 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 xorg-sgml-doctools all 1:1.11-1 [12.9 kB]", "Get:105 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 x11proto-core-dev all 7.0.28-2ubuntu1 [254 kB]", "Get:106 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libice-dev amd64 2:1.0.9-1 [44.9 kB]", "Get:107 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libpthread-stubs0-dev amd64 0.3-4 [4068 B]", "Get:108 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libvorbisenc2 amd64 1.3.5-3 [70.7 kB]", "Get:109 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libsndfile1 amd64 1.0.25-10 [137 kB]", "Err:110 http://us.archive.ubuntu.com/ubuntu xenial-updates/main amd64 libpulse0 amd64 1:8.0-0ubuntu3.2", "  404  Not Found [IP: 91.189.91.23 80]", "Get:111 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libsm-dev amd64 2:1.2.2-1 [16.2 kB]", "Get:112 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxau-dev amd64 1:1.0.8-1 [11.1 kB]", "Get:113 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxdmcp-dev amd64 1:1.1.2-1.1 [25.1 kB]", "Get:114 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 x11proto-input-dev all 2.3.1-1 [118 kB]", "Get:115 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 x11proto-kb-dev all 1.0.7-0ubuntu1 [224 kB]", "Get:116 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 xtrans-dev all 1.3.5-1 [70.5 kB]", "Get:117 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxcb1-dev amd64 1.11.1-1ubuntu1 [74.2 kB]", "Get:118 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libx11-dev amd64 2:1.6.3-1ubuntu2 [642 kB]", "Get:119 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libx11-doc all 2:1.6.3-1ubuntu2 [1465 kB]", "Get:120 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxt6 amd64 1:1.1.5-0ubuntu1 [160 kB]", "Get:121 http://us.archive.ubuntu.com/ubuntu xenial/main amd64 libxt-dev amd64 1:1.1.5-0ubuntu1 [394 kB]", "Err:122 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jre amd64 8u121-b13-0ubuntu1.16.04.2", "  404  Not Found [IP: 91.189.91.23 80]", "Ign:123 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jdk-headless amd64 8u121-b13-0ubuntu1.16.04.2", "Err:122 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jre amd64 8u121-b13-0ubuntu1.16.04.2", "  404  Not Found [IP: 91.189.91.23 80]", "Ign:124 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jdk amd64 8u121-b13-0ubuntu1.16.04.2", "Ign:31 http://security.ubuntu.com/ubuntu xenial-security/main amd64 libnss3-nssdb all 2:3.28.4-0ubuntu0.16.04.1", "Err:123 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jdk-headless amd64 8u121-b13-0ubuntu1.16.04.2", "  404  Not Found [IP: 91.189.91.23 80]", "Err:124 http://security.ubuntu.com/ubuntu xenial-security/main amd64 openjdk-8-jdk amd64 8u121-b13-0ubuntu1.16.04.2", "  404  Not Found [IP: 91.189.91.23 80]", "Err:31 http://security.ubuntu.com/ubuntu xenial-security/main i386 libnss3-nssdb all 2:3.28.4-0ubuntu0.16.04.1", "  404  Not Found [IP: 91.189.91.23 80]", "Err:31 http://security.ubuntu.com/ubuntu xenial-security/main i386 libnss3-nssdb all 2:3.28.4-0ubuntu0.16.04.1", "  404  Not Found [IP: 91.189.91.23 80]", "Fetched 24.7 MB in 6s (3871 kB/s)"]}
```

Thanks!