### PR TITLE
Fix breakage for RedHat distros

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,9 @@
 
 - name: Include version-specific variables for CentOS/RHEL.
   include_vars: "RedHat-{{ ansible_distribution_version.split('.')[0] }}.yml"
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+  when: ansible_distribution == 'CentOS' or
+        ansible_distribution == 'Red Hat Enterprise Linux' or
+        ansible_distribution == 'RedHat'
 
 - name: Include version-specific variables for Ubuntu.
   include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}.yml"


### PR DESCRIPTION
178c334f25bfcfc8cff00e4315198946d9932c11, which was merged yesterday, caused the role to break on RHEL6 environments. Apparently some versions of RHEL report `ansible_distribution` as 'RedHat', not 'Red Hat Enterprise Linux', and not detecting that was causing the vars to not be included, breaking subsequent tasks in the role.

Hoping this can be merged soon, and thanks for providing this useful Ansible role 👍 