### PR TITLE
Add Update Cache to install java apt task

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -14,3 +14,4 @@
   apt:
     name: "{{ java_packages }}"
     state: present
+    update_cache: yes


### PR DESCRIPTION
For fix the following error. ( Ubuntu 16.04 )
```
{"cache_update_time": 1544170931, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'openjdk-8-jdk'' failed: E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/cups/libcups2_2.1.3-4ubuntu0.5_amd64.deb  404  Not Found [IP: 91.189.88.152 80]
```