### PR TITLE
Add Java package downgrade support for Red Hat / CentOS

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,5 +1,6 @@
 ---
 - name: Ensure Java is installed.
-  package:
+  yum:
     name: "{{ java_packages }}"
+    allow_downgrade: true
     state: present


### PR DESCRIPTION
The Ansible 'package' module does not support downgrade - yum does.
Since the minimal Ansible version is defined as 2.4, this should be fine.

Signed-off-by: Samuel Casa <samuel.casa@bluecare.ch>