### PR TITLE
Updated for Debian 10 (buster)

### DIFF
--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,0 +1,6 @@
+---
+# JDK version options include:
+#   - java
+#   - openjdk-11-jdk
+__java_packages:
+  - openjdk-11-jdk


### PR DESCRIPTION
There is no openjdk 8 in Debian 10, it seems it needs to be 11.