### PR TITLE
Principle of Least Privilege applied to ansible

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -2,6 +2,7 @@
 # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199 and
 # https://github.com/geerlingguy/ansible-role-java/issues/64
 - name: Ensure 'man' directory exists.
+  become: True
   file:
     path: /usr/share/man/man1
     state: directory
@@ -11,6 +12,7 @@
     - ansible_distribution_major_version | int >= 18
 
 - name: Ensure Java is installed.
+  become: True
   apt:
     name: "{{ java_packages }}"
     state: present

--- a/tasks/setup-FreeBSD.yml
+++ b/tasks/setup-FreeBSD.yml
@@ -1,11 +1,14 @@
 ---
 - name: Ensure Java is installed.
+  become: True
   pkgng:
     name: "{{ java_packages }}"
     state: present
 
 - name: ensure proc is mounted
+  become: True
   mount: name=/proc fstype=procfs src=proc opts=rw state=mounted
 
 - name: ensure fdesc is mounted
+  become: True
   mount: name=/dev/fd fstype=fdescfs src=fdesc opts=rw state=mounted

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,5 +1,6 @@
 ---
 - name: Ensure Java is installed.
+  become: True
   package:
     name: "{{ java_packages }}"
     state: present


### PR DESCRIPTION
Only use become for tasks that need it instead of giving to the whole role or playbook.

Only tested/check for the setup I'm using so other tasks might also need to be changed, or having become removed from. Which was Vagrant, VirtualBox and Centos 7.