### PR TITLE
Added task to update apt cache

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,6 +1,9 @@
 ---
 # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199 and
 # https://github.com/geerlingguy/ansible-role-java/issues/64
+- name: Update apt cache.
+  apt: update_cache=yes cache_valid_time=3600
+
 - name: Ensure 'man' directory exists.
   file:  # noqa 208
     path: /usr/share/man/man1


### PR DESCRIPTION
Discovered that if you put this as your first role on a new box then the install will fail cause apt update hasn't occurred. If I put it after another role such as apache then it will work. It would seem that it might be best to put an apt update in all roles like this.