### PR TITLE
Update Apt cache before installation

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -14,3 +14,4 @@
   apt:
     name: "{{ java_packages }}"
     state: present
+    update_cache: yes


### PR DESCRIPTION
On a system where Apt has not been run for a while this might fail if Apt cache was not updated before run