### PR TITLE
Changed default java package to java-11-openjdk for Red Hat 7 / CentOS 7 / Fedora

### DIFF
--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -3,4 +3,4 @@
 #   - java
 #   - java-1.8.0-openjdk
 __java_packages:
-  - java-1.8.0-openjdk
+  - java-11-openjdk

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -5,4 +5,4 @@
 #   - java-1.7.0-openjdk
 #   - java-1.8.0-openjdk
 __java_packages:
-  - java-1.8.0-openjdk
+  - java-11-openjdk


### PR DESCRIPTION
```bash
# docker run --rm -it centos:7 yum search java-11-openjdk
==== N/S matched: java-11-openjdk ====
java-11-openjdk.i686 : OpenJDK Runtime Environment 11                                                                                            
java-11-openjdk.x86_64 : OpenJDK 11 Runtime Environment
```

```bash
# docker run --rm -it fedora:latest yum search --disablerepo=extras java-11-openjdk
==== Name Exactly Matched: java-11-openjdk ====
java-11-openjdk.i686 : OpenJDK 11 Runtime Environment
java-11-openjdk.x86_64 : OpenJDK 11 Runtime Environment
```