### PR TITLE
Use FQCN for module names

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   when: ansible_os_family == 'Debian'
 
 - name: Define java_packages.
-  set_fact:
+  ansible.builtin.set_fact:
     java_packages: "{{ __java_packages | list }}"
   when: java_packages is not defined
 
@@ -34,7 +34,7 @@
 
 # Environment setup.
 - name: Set JAVA_HOME if configured.
-  template:
+  ansible.builtin.template:
     src: java_home.sh.j2
     dest: /etc/profile.d/java_home.sh
     mode: 0644

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -2,7 +2,7 @@
 # See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199 and
 # https://github.com/geerlingguy/ansible-role-java/issues/64
 - name: Ensure 'man' directory exists.
-  file:  # noqa 208
+  ansible.builtin.file:  # noqa 208
     path: /usr/share/man/man1
     state: directory
     mode: 0755
@@ -12,6 +12,6 @@
     - ansible_distribution_major_version | int >= 18
 
 - name: Ensure Java is installed.
-  apt:
+  ansible.builtin.apt:
     name: "{{ java_packages }}"
     state: present

--- a/tasks/setup-FreeBSD.yml
+++ b/tasks/setup-FreeBSD.yml
@@ -1,11 +1,11 @@
 ---
 - name: Ensure Java is installed.
-  pkgng:
+  community.general.pkgng:
     name: "{{ java_packages }}"
     state: present
 
 - name: ensure proc is mounted
-  mount: name=/proc fstype=procfs src=proc opts=rw state=mounted
+  ansible.posix.mount: name=/proc fstype=procfs src=proc opts=rw state=mounted
 
 - name: ensure fdesc is mounted
-  mount: name=/dev/fd fstype=fdescfs src=fdesc opts=rw state=mounted
+  ansible.posix: name=/dev/fd fstype=fdescfs src=fdesc opts=rw state=mounted

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,5 +1,5 @@
 ---
 - name: Ensure Java is installed.
-  package:
+  ansible.builtin.package:
     name: "{{ java_packages }}"
     state: present


### PR DESCRIPTION
Ansible is switching to only using FQCN names for modules (like ansible.builtin.apt instead of apt).
Even though the old way is still supported, it's advised to change them.
 As you can see in all the official Ansible examples,  the FQCNs are already used there.