### PR TITLE
Style improvements

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,7 +5,9 @@
 
   pre_tasks:
     - name: Update apt cache.
-      apt: update_cache=true cache_valid_time=600
+      apt:
+        update_cache: true
+        cache_valid_time: 600
       when: ansible_os_family == 'Debian'
       changed_when: false
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
   when: ansible_distribution == 'Ubuntu'
 
 - name: Include version-specific variables for Debian.
-  include_vars: "{{ ansible_distribution|title }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
+  include_vars: "{{ ansible_distribution | title }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
   when: ansible_os_family == 'Debian'
 
 - name: Define java_packages.

--- a/tasks/setup-FreeBSD.yml
+++ b/tasks/setup-FreeBSD.yml
@@ -4,8 +4,18 @@
     name: "{{ java_packages }}"
     state: present
 
-- name: ensure proc is mounted
-  mount: name=/proc fstype=procfs src=proc opts=rw state=mounted
+- name: Ensure proc is mounted
+  mount:
+    name: /proc
+    fstype: procfs
+    src: proc
+    opts: rw
+    state: mounted
 
-- name: ensure fdesc is mounted
-  mount: name=/dev/fd fstype=fdescfs src=fdesc opts=rw state=mounted
+- name: Ensure fdesc is mounted
+  mount:
+    name: /dev/fd
+    fstype: fdescfs
+    src: fdesc
+    opts: rw
+    state: mounted


### PR DESCRIPTION
This PR has a few changes for a consistent code style #123 :

- One Jinja2 filter was not separated with spaces, others were.
- The `setup-FreeBSD.yml` still used key=value style for module arguments, and lowercase task name in two cases.