### PR TITLE
Remove recursion from /usr/share/man/man1 creation

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,7 +6,6 @@
     path: /usr/share/man/man1
     state: directory
     mode: 0755
-    recurse: true
   when:
     - ansible_distribution == 'Ubuntu'
     - ansible_distribution_major_version | int >= 18


### PR DESCRIPTION
This would otherwise cause the mode to be set to 0755 for all contained manpage files as well.

Addresses #130.