### PR TITLE
Update Ubuntu-22.yml

### DIFF
--- a/vars/Ubuntu-22.yml
+++ b/vars/Ubuntu-22.yml
@@ -3,4 +3,4 @@
 #   - java
 #   - openjdk-18-jdk
 __java_packages:
-  - openjdk-18-jdk
+  - openjdk-17-jdk


### PR DESCRIPTION
Java 17 is the Java long term support version, while Java 18 is already out of maintenance. As default I suggest to use Java 17 even for latest Ubuntu.