### PR TITLE
Add Oracle Linux to CentOS/RHEL suite

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
       'CentOS',
       'Red Hat Enterprise Linux',
       'RedHat',
+      'OracleLinux',
       'Rocky',
       'AlmaLinux'
     ]


### PR DESCRIPTION
I've tested this on Oracle Linux 9, and it seems to be working, for this ansible role anyways...