### PR TITLE
fix: allows Rocky Linux to install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,15 @@
 
 # Setup/install tasks.
 - include_tasks: setup-RedHat.yml
-  when: ansible_os_family == 'RedHat'
+  when: >-
+    ansible_os_family in [
+      'CentOS',
+      'Red Hat Enterprise Linux',
+      'RedHat',
+      'OracleLinux',
+      'Rocky',
+      'AlmaLinux'
+    ]
 
 - include_tasks: setup-Amazon.yml
   when: ansible_distribution == 'Amazon'


### PR DESCRIPTION
Problem:
Was trying to install java 11 openjdk on an AWS Rocky Linux 9 VM and it was skipping the actual installation include constantly.

**notes:** 
 - ansible version 2.9.27 (because it's LTS version for RedHat of course)
 - python 3.12

Investigation: 
Rocky Linux 9 appears to not identify as the OS family "RedHat" all of the time for some reason, possibly identifying dependent on how it was called.
1. via an `ansible -i ec2.py prod.yml`
```
TASK [debug ansible OS family] ***********************************************************************************
ok: [some.ip.numbers.here] => {
    "msg": "Rocky"
}

TASK [debug ansible distribution] **********************************************************************************
ok: [same.ip.numbers.here] => {
    "msg": "Rocky"
}
```
along with debugging at `-vvvvv`
```
ansible_distribution": "Rocky", "ansible_distribution_release": "Blue Onyx", "ansible_distribution_version": "9.4", "ansible_distribution_major_version": "9", "ansible_distribution_file_path": "/etc/redhat-release", "ansible_distribution_file_variety": "RedHat", "ansible_distribution_file_parsed": true, "ansible_os_family": "Rocky",
```

2. however via `ansible localhost -m ansible.builtin.setup` on the server:
```
...
        "ansible_distribution": "Rocky",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/redhat-release",
        "ansible_distribution_file_variety": "RedHat",
        "ansible_distribution_major_version": "9",
        "ansible_distribution_release": "Blue Onyx",
        "ansible_distribution_version": "9.4",
...
        "ansible_nodename": "<sshh secret>",
        "ansible_os_family": "RedHat",
...
```

Took a look at an Azure Rocky Linux 9 machine and it does the same thing. 

Fix:
Maybe this is a 2.9.x problem only but I applied the ansible_distribution array to the ansible_os_family section as well to fix the issue in order to get the `setup-RedHat.yml` include for Java to install.