### PR TITLE
Solve "Conditionals must have a boolean result." error message.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,4 +51,4 @@
     src: java_home.sh.j2
     dest: /etc/profile.d/java_home.sh
     mode: 0644
-  when: java_home is defined and java_home
+  when: java_home is defined and java_home != ""


### PR DESCRIPTION
I'm getting the current error:

```txt
[ERROR]: Task failed: Conditional result (False) was derived from value of type 'str' at '/home/pc/workspace/ivan/roles/geerlingguy.java/defaults/main.yml:6:12'. Conditionals must have a boolean result.

Task failed.
Origin: /home/pc/workspace/ivan/roles/geerlingguy.java/tasks/main.yml:49:3

47
48 # Environment setup.
49 - name: Set JAVA_HOME if configured.
     ^ column 3

<<< caused by >>>

Conditional result (False) was derived from value of type 'str' at '/home/pc/workspace/ivan/roles/geerlingguy.java/defaults/main.yml:6:12'. Conditionals must have a boolean result.
Origin: /home/pc/workspace/ivan/roles/geerlingguy.java/tasks/main.yml:54:9

52     dest: /etc/profile.d/java_home.sh
53     mode: 0644
54   when: java_home is defined and java_home
           ^ column 9

Broken conditionals can be temporarily allowed with the `ALLOW_BROKEN_CONDITIONALS` configuration option.
```

This solves the issue for me, but I'm not sure why I'm getting the error now and not in the past.

```bash
ansible --version
ansible [core 2.19.1]
  config file = /home/pc/workspace/ivan/ansible.cfg
  configured module search path = ['/home/pc/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/pc/workspace/ivan/.venv/lib/python3.12/site-packages/ansible
  ansible collection location = /home/pc/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/pc/workspace/ivan/.venv/bin/ansible
  python version = 3.12.3 (main, Aug 14 2025, 17:47:21) [GCC 13.3.0] (/home/pc/workspace/ivan/.venv/bin/python)
  jinja version = 3.1.6
  pyyaml version = 6.0.2 (with libyaml v0.2.5)
```