### PR TITLE
Add Ubuntu 26.04 (Resolute) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         distro:
           - rockylinux9
           - rockylinux10
+          - ubuntu2604
           - ubuntu2404
           - ubuntu2204
           - debian13

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,6 +29,7 @@ galaxy_info:
         - focal
         - jammy
         - noble
+        - resolute
     - name: FreeBSD
       versions:
         - 10.2

--- a/vars/Ubuntu-26.yml
+++ b/vars/Ubuntu-26.yml
@@ -1,6 +1,6 @@
 ---
 # JDK version options include:
-#   - openjdk-25-jdk (default, non-LTS, in main)
+#   - openjdk-25-jdk (default, non-LTS)
 #   - openjdk-21-jdk (LTS, in universe)
 #   - openjdk-17-jdk (LTS, in universe)
 #   - openjdk-11-jdk (LTS, in universe)

--- a/vars/Ubuntu-26.yml
+++ b/vars/Ubuntu-26.yml
@@ -1,7 +1,9 @@
 ---
 # JDK version options include:
-#   - openjdk-25-jdk (default, non-LTS)
+#   - openjdk-25-jdk (default, non-LTS, in main)
 #   - openjdk-21-jdk (LTS, in universe)
 #   - openjdk-17-jdk (LTS, in universe)
+#   - openjdk-11-jdk (LTS, in universe)
+#   - openjdk-8-jdk (LTS, in universe)
 __java_packages:
   - openjdk-25-jdk

--- a/vars/Ubuntu-26.yml
+++ b/vars/Ubuntu-26.yml
@@ -1,0 +1,7 @@
+---
+# JDK version options include:
+#   - openjdk-25-jdk (default, non-LTS)
+#   - openjdk-21-jdk (LTS, in universe)
+#   - openjdk-17-jdk (LTS, in universe)
+__java_packages:
+  - openjdk-25-jdk


### PR DESCRIPTION
> [!NOTE]
> The work on this PR was sponsored by [Devopness](https://github.com/devopness/devopness) 

## Summary

This PR adds support for Ubuntu 26.04 (Resolute) by creating the `vars/Ubuntu-26.yml` file with appropriate JDK package definitions.

## Changes

- Added `vars/Ubuntu-26.yml` with `openjdk-25-jdk` as the default JDK package
- Updated `meta/main.yml` to include `resolute` in supported Ubuntu versions
- Added `ubuntu2604` to the CI test matrix in `.github/workflows/ci.yml`

## Ubuntu 26.04 JDK Packages

Ubuntu 26.04 introduces Java 25 as the default JDK, moving from Java 21 in Ubuntu 24.04.

### Standard JDK Packages

| Package        | Version | LTS | Repository | Link                                                                       |
| -------------- | ------- | --- | ---------- | -------------------------------------------------------------------------- |
| openjdk-25-jdk | 25      | No  | **main**   | [packages.ubuntu.com](https://packages.ubuntu.com/resolute/openjdk-25-jdk) |
| openjdk-21-jdk | 21      | Yes | universe   | [packages.ubuntu.com](https://packages.ubuntu.com/resolute/openjdk-21-jdk) |
| openjdk-17-jdk | 17      | Yes | universe   | [packages.ubuntu.com](https://packages.ubuntu.com/resolute/openjdk-17-jdk) |
| openjdk-11-jdk | 11      | Yes | universe   | [packages.ubuntu.com](https://packages.ubuntu.com/resolute/openjdk-11-jdk) |
| openjdk-8-jdk  | 8       | Yes | universe   | [packages.ubuntu.com](https://packages.ubuntu.com/resolute/openjdk-8-jdk)  |

You can verify available packages directly:
```bash
docker run --rm ubuntu:26.04 bash -c "apt-get update -qq && apt-cache search '^openjdk-.*-jdk$' | sort"
```

## Testing

Tested with Molecule using `molecule/default/molecule.yml`:

```bash
MOLECULE_DISTRO="ubuntu2604" molecule test --scenario-name default
```
